### PR TITLE
Add right packages to example config for *arr

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -33,13 +33,13 @@ jackett: jackett
   pkgs: mono
  
 radarr: radarr
-  pkgs: mono
+  pkgs: mono mediainfo sqlite3 libgdiplus
  
 sonarr: sonarr
-  pkgs: mono
+  pkgs: mono mediainfo sqlite3
  
 lidarr: lidarr
-  pkgs: mono
+  pkgs: mono mediainfo sqlite3
  
 transmission: transmission
   pkgs: bash unzip unrar transmission


### PR DESCRIPTION
It seems some required packages where not included for Sonarr Radarr and Lidarr.
No idea why testing went fine for 1.1.0, but some people reported problems either way.