### PR TITLE
Jail-Specific config.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-config.yml
+/config.yml

--- a/config.yml.example
+++ b/config.yml.example
@@ -28,42 +28,15 @@ example: example
   # Jail specific pkgs. 
   # Please use standard space delimited pkg install syntax.
   pkgs: mono
- 
-jackett: jackett
-  pkgs: mono
- 
-radarr: radarr
-  pkgs: mono mediainfo sqlite3 libgdiplus
- 
-sonarr: sonarr
-  pkgs: mono mediainfo sqlite3
- 
-lidarr: lidarr
-  pkgs: mono mediainfo sqlite3
- 
-transmission: transmission
-  pkgs: bash unzip unrar transmission
   
 plex: plex
   plexpass: false
-  pkgs: plexmediaserver
-  
-tautulli: tautulli
-  pkgs: python2 py27-sqlite3 py27-openssl git
-  
-organizr: organizr
-  pkgs: nginx php72 php72-filter php72-curl php72-hash php72-json php72-openssl php72-pdo php72-pdo_sqlite php72-session php72-simplexml php72-sqlite3 php72-zip git
-  
-kms: kms
-  pkgs: bash py37-tkinter py37-pip py37-sqlite3 git
-
 
 nextcloud: nextcloud
   ip4_addr: 192.168.1.99/24
   gateway: 192.168.1.1
   time_zone: Europe/Amsterdam
   host_name: cloud.example.com
-  pkgs:   nano sudo redis php73-ctype gnupg php73-dom php73-gd php73-iconv php73-json php73-mbstring php73-posix php73-simplexml php73-xmlreader php73-xmlwriter php73-zip php73-zlib php73-hash php73-xml php73 php73-pecl-redis php73-session php73-wddx php73-xsl php73-filter php73-pecl-APCu php73-curl php73-fileinfo php73-bz2 php73-intl php73-openssl php73-ldap php73-ftp php73-imap php73-exif php73-gmp php73-pecl-memcache php73-pecl-imagick perl5 p5-Locale-gettext help2man texinfo m4 autoconf
   database: mariadb
   standalone_cert: 0
   selfsigned_cert: 0
@@ -81,14 +54,12 @@ nextcloud: nextcloud
 mariadb: mariadb
   ip4_addr: 192.168.1.98/24
   gateway: 192.168.1.1
-  pkgs: mariadb104-server git  php74-session php74-xml php74-ctype php74-openssl php74-filter php74-gd php74-json php74-mysqli php74-mbstring php74-zlib php74-zip php74-bz2 phpMyAdmin5-php74 php74-pdo_mysql php74-mysqli phpMyAdmin5-php74-5.0.1
   db_root_password: ReplaceThisWithYourOwnRootPAssword
   host_name: mariadb.local.example
 
 bitwarden: bitwarden
   ip4_addr: 192.168.1.97/24
   gateway: 192.168.1.1
-  pkgs: sqlite3 nginx git sudo vim-tiny bash node npm python27-2.7.17_1 mariadb104-client
   db_password: "YourDBPasswordHerePLEASE"
   type: mariadb
   admin_token: "PUTYOURADMINTOKENHEREANDREMOVETHIS"
@@ -96,5 +67,4 @@ bitwarden: bitwarden
 influxdb: influxdb
   ip4_addr: 192.168.1.250/24
   gateway: 192.168.1.1
-  pkgs: influxdb
   database: influxdb

--- a/jailman.sh
+++ b/jailman.sh
@@ -85,6 +85,7 @@ while getopts ":i:r:u:d:g:h" opt
 done
 
 # Parse the Config YAML
+for configpath in ${SCRIPT_DIR}/jails/*/config.yml; do ! eval $(parse_yaml ${configpath}); done
 eval $(parse_yaml config.yml)
 
 # Check and Execute requested jail destructions

--- a/jails/bitwarden/config.yml
+++ b/jails/bitwarden/config.yml
@@ -1,0 +1,2 @@
+bitwarden: bitwarden
+  pkgs: sqlite3 nginx git sudo vim-tiny bash node npm python27-2.7.17_1 mariadb104-client

--- a/jails/influxdb/config.yml
+++ b/jails/influxdb/config.yml
@@ -1,0 +1,2 @@
+influxdb: influxdb
+  pkgs: influxdb

--- a/jails/jackett/config.yml
+++ b/jails/jackett/config.yml
@@ -1,0 +1,2 @@
+jackett: jackett
+  pkgs: mono

--- a/jails/kms/config.yml
+++ b/jails/kms/config.yml
@@ -1,0 +1,2 @@
+kms: kms
+  pkgs: bash py37-tkinter py37-pip py37-sqlite3 git

--- a/jails/lidarr/config.yml
+++ b/jails/lidarr/config.yml
@@ -1,0 +1,2 @@
+lidarr: lidarr
+  pkgs: mono

--- a/jails/lidarr/config.yml
+++ b/jails/lidarr/config.yml
@@ -1,2 +1,2 @@
 lidarr: lidarr
-  pkgs: mono
+  pkgs: mono mediainfo sqlite3

--- a/jails/mariadb/config.yml
+++ b/jails/mariadb/config.yml
@@ -1,0 +1,2 @@
+mariadb: mariadb
+  pkgs: mariadb104-server git  php74-session php74-xml php74-ctype php74-openssl php74-filter php74-gd php74-json php74-mysqli php74-mbstring php74-zlib php74-zip php74-bz2 phpMyAdmin5-php74 php74-pdo_mysql php74-mysqli phpMyAdmin5-php74-5.0.1

--- a/jails/nextcloud/config.yml
+++ b/jails/nextcloud/config.yml
@@ -1,0 +1,2 @@
+nextcloud: nextcloud
+  pkgs:   nano sudo redis php73-ctype gnupg php73-dom php73-gd php73-iconv php73-json php73-mbstring php73-posix php73-simplexml php73-xmlreader php73-xmlwriter php73-zip php73-zlib php73-hash php73-xml php73 php73-pecl-redis php73-session php73-wddx php73-xsl php73-filter php73-pecl-APCu php73-curl php73-fileinfo php73-bz2 php73-intl php73-openssl php73-ldap php73-ftp php73-imap php73-exif php73-gmp php73-pecl-memcache php73-pecl-imagick perl5 p5-Locale-gettext help2man texinfo m4 autoconf

--- a/jails/organizr/config.yml
+++ b/jails/organizr/config.yml
@@ -1,0 +1,2 @@
+organizr: organizr
+  pkgs: nginx php72 php72-filter php72-curl php72-hash php72-json php72-openssl php72-pdo php72-pdo_sqlite php72-session php72-simplexml php72-sqlite3 php72-zip git

--- a/jails/plex/config.yml
+++ b/jails/plex/config.yml
@@ -1,0 +1,2 @@
+plex: plex
+  pkgs: plexmediaserver

--- a/jails/radarr/config.yml
+++ b/jails/radarr/config.yml
@@ -1,0 +1,2 @@
+radarr: radarr
+  pkgs: mono

--- a/jails/radarr/config.yml
+++ b/jails/radarr/config.yml
@@ -1,2 +1,2 @@
 radarr: radarr
-  pkgs: mono
+  pkgs: mono mediainfo sqlite3 libgdiplus

--- a/jails/sonarr/config.yml
+++ b/jails/sonarr/config.yml
@@ -1,0 +1,2 @@
+sonarr: sonarr
+  pkgs: mono

--- a/jails/sonarr/config.yml
+++ b/jails/sonarr/config.yml
@@ -1,2 +1,2 @@
 sonarr: sonarr
-  pkgs: mono
+  pkgs: mono mediainfo sqlite3

--- a/jails/tautulli/config.yml
+++ b/jails/tautulli/config.yml
@@ -1,0 +1,2 @@
+tautulli: tautulli
+  pkgs: python2 py27-sqlite3 py27-openssl git

--- a/jails/transmission/config.yml
+++ b/jails/transmission/config.yml
@@ -1,0 +1,2 @@
+transmission: transmission
+  pkgs: bash unzip unrar transmission


### PR DESCRIPTION
This draft PR introduces the ability to add a config.yml to every jail, containing non-user config settings like the PKG list.

It's very basic and not fully tested at the moment, but it gives an impression about it.
With this implemented jail maintainers could for example change the required packages with an update, something that isn't possible when the package list is included in the user config like it is now.

Closes #43 