### PR TITLE
Rename plexpass to beta and document the beta flag

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -30,7 +30,7 @@ example: example
   pkgs: mono
   
 plex: plex
-  plexpass: false
+  beta: false
 
 nextcloud: nextcloud
   ip4_addr: 192.168.1.99/24

--- a/jails/plex/install.sh
+++ b/jails/plex/install.sh
@@ -21,15 +21,15 @@ iocage exec plex chown -R plex:plex /config
 iocage exec plex pkg update
 iocage exec plex pkg upgrade -y
 
-# Run different install procedures depending on Plex vs Plexpass
-if [ "$plex_plexpass" == "true" ]; then
-	echo "plexpass enabled in config.yml... using plexpass for install"
+# Run different install procedures depending on Plex vs Plex Beta
+if [ "$plex_beta" == "true" ]; then
+	echo "beta enabled in config.yml... using plex beta for install"
 	iocage exec plex sysrc "plexmediaserver_plexpass_enable=YES"
 	iocage exec plex sysrc plexmediaserver_plexpass_support_path="/config"
 	iocage exec plex chown -R plex:plex /usr/local/share/plexmediaserver-plexpass/
 	iocage exec plex service plexmediaserver_plexpass restart
 else
-	echo "plexpass disabled in config.yml... NOT using plexpass for install"
+	echo "beta disabled in config.yml... NOT using plex beta for install"
 	iocage exec plex sysrc "plexmediaserver_enable=YES"
 	iocage exec plex sysrc plexmediaserver_support_path="/config"
 	iocage exec plex chown -R plex:plex /usr/local/share/plexmediaserver/

--- a/jails/plex/readme.md
+++ b/jails/plex/readme.md
@@ -1,5 +1,8 @@
 # Plex
 
+### Config Parameters:
+- beta: set to `true` if you want to run the plex beta (previously known as "plexpass"). Please note: This is not required for plexpass features
+
 For more information about plex, please see the Plex website:
 
 # Original plex install script guide

--- a/jails/plex/update.sh
+++ b/jails/plex/update.sh
@@ -3,13 +3,13 @@
 
 # Run different update procedures depending on Plex vs Plexpass
 if [ "$plex_plexpass" == "true" ]; then
-	echo "plexpass enabled in config.yml... using plexpass for update..."
+	echo "beta enabled in config.yml... using plex beta for update..."
 	iocage exec plex service plexmediaserver_plexpass stop
 	# Plex is updated using PKG already, this is mostly a placeholder
 	iocage exec plex chown -R plex:plex /usr/local/share/plexmediaserver-plexpass/
 	iocage exec plex service plexmediaserver_plexpass restart
 else
-	echo "plexpass disabled in config.yml... NOT using plexpass for update..."
+	echo "beta disabled in config.yml... NOT using plex beta for update..."
 	iocage exec plex service plexmediaserver stop
 	# Plex is updated using PKG already, this is mostly a placeholder
 	iocage exec plex chown -R plex:plex /usr/local/share/plexmediaserver/

--- a/jails/plex/update.sh
+++ b/jails/plex/update.sh
@@ -1,7 +1,7 @@
 #!/usr/local/bin/bash
 # This file contains the update script for Plex
 
-# Run different update procedures depending on Plex vs Plexpass
+# Run different update procedures depending on Plex vs Plex Beta
 if [ "$plex_plexpass" == "true" ]; then
 	echo "beta enabled in config.yml... using plex beta for update..."
 	iocage exec plex service plexmediaserver_plexpass stop


### PR DESCRIPTION
Simple fix for #54 
Plexpass is now named beta and the function has been documented in the readme.