### PR TITLE
add plex user to video group

### DIFF
--- a/jails/plex/install.sh
+++ b/jails/plex/install.sh
@@ -21,6 +21,9 @@ iocage exec plex chown -R plex:plex /config
 iocage exec plex pkg update
 iocage exec plex pkg upgrade -y
 
+# Add plex user to video group for future hw-encoding support
+iocage exec plex pw groupmod -n video -m plex
+
 # Run different install procedures depending on Plex vs Plex Beta
 if [ "$plex_beta" == "true" ]; then
 	echo "beta enabled in config.yml... using plex beta for install"


### PR DESCRIPTION
- add plex user to video group to enable future hardware encoding jail side. (Fixes: #20)

Thanks to @thorsteneb for checking upstream and verifying it isn't required to add drivers. So only the video group add was needed inside the jail. This finishes #20.