### PR TITLE
Add plex transcoding ramdisk creation

### DIFF
--- a/jails/plex/install.sh
+++ b/jails/plex/install.sh
@@ -14,6 +14,12 @@ createmount plex ${global_dataset_media}/movies /mnt/media/movies
 createmount plex ${global_dataset_media}/music /mnt/media/music
 createmount plex ${global_dataset_media}/shows /mnt/media/shows
 
+# Create plex ramdisk if specified
+if [ -z "${plex_ramdisk}" ]; then
+	echo "no ramdisk specified for plex, continuing without randisk"
+else
+	iocage fstab -a plex tmpfs /tmp_transcode tmpfs rw,size=${plex_ramdisk},mode=1777 0 0
+fi
 
 iocage exec plex chown -R plex:plex /config
 

--- a/jails/plex/readme.md
+++ b/jails/plex/readme.md
@@ -2,6 +2,10 @@
 
 For more information about plex, please see the Plex website:
 
+### Config Parameters:
+
+- ramdisk: Specify the `size` parameter to create a transcoding ramdisk under /tmp_transcode. Requires manual setting it un plex to be used for transcoding. (optional)
+
 # Original plex install script guide
 
 https://www.ixsystems.com/community/resources/fn11-3-iocage-jails-plex-tautulli-sonarr-radarr-lidarr-jackett-transmission-organizr.58/


### PR DESCRIPTION
This PR adds the option to specify a size, to create a ramdisk for plex transcodes.
It does not add privilages to the jail, it's done from the host for security reasons.

Still requires the ramdisk to be added to the plex config manually.
Also documents the ramdisk config parameter

Closes #23 