### PR TITLE
Add transmission+openvpn, qbittorrent+openvpn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config.yml
+openvpn.conf
+openvpn-*

--- a/config.yml.example
+++ b/config.yml.example
@@ -48,7 +48,8 @@ transvpn: transvpn
   pkgs: bash unzip unrar transmission openvpn
   ovpnconf: openvpn.conf
   extraconf: allow_tun=1
-  
+  tundev: tun0
+
 plex: plex
   plexpass: false
   pkgs: plexmediaserver

--- a/config.yml.example
+++ b/config.yml.example
@@ -43,6 +43,11 @@ lidarr: lidarr
  
 transmission: transmission
   pkgs: bash unzip unrar transmission
+
+transvpn: transvpn
+  pkgs: bash unzip unrar transmission openvpn
+  ovpnconf: openvpn.conf
+  extraconf: allow_tun=1
   
 plex: plex
   plexpass: false

--- a/config.yml.example
+++ b/config.yml.example
@@ -50,6 +50,12 @@ transvpn: transvpn
   extraconf: allow_tun=1
   tundev: tun0
 
+qbitvpn: qbitvpn
+  pkgs: bash unzip unrar qbittorrent-nox openvpn
+  ovpnconf: openvpn.conf
+  extraconf: allow_tun=1
+  tundev: tun10
+
 plex: plex
   plexpass: false
   pkgs: plexmediaserver

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -79,6 +79,7 @@ Basic means: The same setup as a FreeNAS plugin would've, DHCP on bridge0.
 #### Downloads
 
 - transmission
+- transvpn (transmission + openvpn)
 - jackett
 
 #### Media

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -80,6 +80,7 @@ Basic means: The same setup as a FreeNAS plugin would've, DHCP on bridge0.
 
 - transmission
 - transvpn (transmission + openvpn)
+- qbitvpn (qbittorrent + openvpn)
 - jackett
 
 #### Media

--- a/global.sh
+++ b/global.sh
@@ -47,6 +47,8 @@ jailip4="${1}_ip4_addr"
 jailgateway="${1}_gateway"
 jaildhcp="${1}_dhcp"
 setdhcp=${!jaildhcp}
+extraconf="${1}_extraconf"
+setextra="${!extraconf}"
 
 if [ -z "${!jailinterfaces}" ]; then 
 	jailinterfaces="vnet0:bridge0"
@@ -68,13 +70,13 @@ else
 	echo '{"pkgs":['${pkgs}']}' > /tmp/pkg.json
 	if [ "${setdhcp}" == "on" ]
 	then
-		if ! iocage create -n "${1}" -p /tmp/pkg.json -r ${global_jails_version} interfaces="${jailinterfaces}" dhcp="on" vnet="on" allow_raw_sockets="1" boot="on"
+		if ! iocage create -n "${1}" -p /tmp/pkg.json -r ${global_jails_version} interfaces="${jailinterfaces}" dhcp="on" vnet="on" allow_raw_sockets="1" boot="on" ${setextra}
 		then
 			echo "Failed to create jail"
 			exit 1
 		fi
 	else
-		if ! iocage create -n "${1}" -p /tmp/pkg.json -r ${global_jails_version} interfaces="${jailinterfaces}" ip4_addr="vnet0|${!jailip4}" defaultrouter="${!jailgateway}" vnet="on" allow_raw_sockets="1" boot="on"
+		if ! iocage create -n "${1}" -p /tmp/pkg.json -r ${global_jails_version} interfaces="${jailinterfaces}" ip4_addr="vnet0|${!jailip4}" defaultrouter="${!jailgateway}" vnet="on" allow_raw_sockets="1" boot="on" ${setextra}
 		then
 			echo "Failed to create jail"
 			exit 1

--- a/jails/qbitvpn/includes/ipfw.rules
+++ b/jails/qbitvpn/includes/ipfw.rules
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Flush out the list before we begin
+ipfw -q -f flush
+
+# Set rules command prefix
+cmd="ipfw -q add"
+vpn="#TUNDEV#"
+
+# allow all local traffic on the loopback interface
+$cmd 00001 allow all from any to any via lo0
+
+# allow any connection to/from VPN interface
+$cmd 00010 allow all from any to any via $vpn
+
+# allow connection to/from LAN by qbittorrent
+$cmd 00101 allow all from me to 192.168.0.0/16 uid qbittorrent
+$cmd 00102 allow all from 192.168.0.0/16 to me uid qbittorrent
+
+# deny any connection outside LAN that does not use VPN
+$cmd 00103 deny all from any to any uid qbittorrent

--- a/jails/qbitvpn/install.sh
+++ b/jails/qbitvpn/install.sh
@@ -1,20 +1,21 @@
 #!/usr/local/bin/bash
 # This file contains the install script for qbittorrent + vpn
 set -eao pipefail
+
 # Ensure nothing happens before config
 iocage exec qbitvpn service qbittorrent stop || true
 
 # Check if dataset Downloads dataset exist, create if they do not.
-createmount qbitvpn ${global_dataset_downloads}qbit /mnt/downloads
+createmount qbitvpn "${global_dataset_downloads}qbit" /mnt/downloads
 
 # Check if dataset Complete Downloads dataset exist, create if they do not.
-createmount qbitvpn ${global_dataset_downloads}qbit/complete /mnt/downloads/complete
+createmount qbitvpn "${global_dataset_downloads}qbit/complete" /mnt/downloads/complete
 
 # Check if dataset InComplete Downloads dataset exist, create if they do not.
-createmount qbitvpn ${global_dataset_downloads}qbit/incomplete /mnt/downloads/incomplete
+createmount qbitvpn "${global_dataset_downloads}qbit/incomplete" /mnt/downloads/incomplete
 
 # Copy ipfw rules to jail, replacing #TUNDEV# with tundev (default "tun0")
-sed -e "s/#TUNDEV#/${qbitvpn_tundev:-tun0}/g" < ${SCRIPT_DIR}/jails/qbitvpn/includes/ipfw.rules > /mnt/${global_dataset_iocage}/jails/qbitvpn/root/etc/ipfw.rules
+sed -e "s/#TUNDEV#/${qbitvpn_tundev:-tun0}/g" < "${SCRIPT_DIR}/jails/qbitvpn/includes/ipfw.rules" > "/mnt/${global_dataset_iocage}/jails/qbitvpn/root/etc/ipfw.rules"
 iocage exec qbitvpn chmod +x /etc/ipfw.rules
 iocage exec qbitvpn sysrc "firewall_enable=YES"
 iocage exec qbitvpn sysrc "firewall_script=/etc/ipfw.rules"
@@ -27,7 +28,7 @@ iocage exec qbitvpn sysrc "qbittorrent_download_dir=/mnt/downloads/complete"
 
 iocage exec qbitvpn sysrc "openvpn_enable=YES"
 iocage exec qbitvpn mkdir /usr/local/etc/openvpn
-cp ${SCRIPT_DIR}/${qbitvpn_ovpnconf} /mnt/${global_dataset_iocage}/jails/qbitvpn/root/usr/local/etc/openvpn/
+cp "${SCRIPT_DIR}/${qbitvpn_ovpnconf}" "/mnt/${global_dataset_iocage}/jails/qbitvpn/root/usr/local/etc/openvpn/"
 
 iocage exec qbitvpn service ipfw restart
 iocage exec qbitvpn service openvpn restart

--- a/jails/qbitvpn/install.sh
+++ b/jails/qbitvpn/install.sh
@@ -1,0 +1,36 @@
+#!/usr/local/bin/bash
+# This file contains the install script for qbittorrent + vpn
+set -eao pipefail
+# Ensure nothing happens before config
+iocage exec qbitvpn service qbittorrent stop || true
+
+# Check if dataset Downloads dataset exist, create if they do not.
+createmount qbitvpn ${global_dataset_downloads}qbit /mnt/downloads
+
+# Check if dataset Complete Downloads dataset exist, create if they do not.
+createmount qbitvpn ${global_dataset_downloads}qbit/complete /mnt/downloads/complete
+
+# Check if dataset InComplete Downloads dataset exist, create if they do not.
+createmount qbitvpn ${global_dataset_downloads}qbit/incomplete /mnt/downloads/incomplete
+
+# Copy ipfw rules to jail, replacing #TUNDEV# with tundev (default "tun0")
+sed -e "s/#TUNDEV#/${qbitvpn_tundev:-tun0}/g" < ${SCRIPT_DIR}/jails/qbitvpn/includes/ipfw.rules > /mnt/${global_dataset_iocage}/jails/qbitvpn/root/etc/ipfw.rules
+iocage exec qbitvpn chmod +x /etc/ipfw.rules
+iocage exec qbitvpn sysrc "firewall_enable=YES"
+iocage exec qbitvpn sysrc "firewall_script=/etc/ipfw.rules"
+
+iocage exec qbitvpn chown -R qbittorrent: /config /mnt/downloads
+
+iocage exec qbitvpn sysrc "qbittorrent_enable=YES"
+iocage exec qbitvpn sysrc "qbittorrent_conf_dir=/config"
+iocage exec qbitvpn sysrc "qbittorrent_download_dir=/mnt/downloads/complete"
+
+iocage exec qbitvpn sysrc "openvpn_enable=YES"
+iocage exec qbitvpn mkdir /usr/local/etc/openvpn
+cp ${SCRIPT_DIR}/${qbitvpn_ovpnconf} /mnt/${global_dataset_iocage}/jails/qbitvpn/root/usr/local/etc/openvpn/
+
+iocage exec qbitvpn service ipfw restart
+iocage exec qbitvpn service openvpn restart
+
+iocage exec qbitvpn sed -i '' -e 's_/config/qBittorrent/downloads/_/mnt/downloads/complete/_g' /config/qBittorrent/config/qBittorrent.conf
+iocage exec qbitvpn service qbittorrent start

--- a/jails/transvpn/includes/ipfw.rules
+++ b/jails/transvpn/includes/ipfw.rules
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Flush out the list before we begin
+ipfw -q -f flush
+
+# Set rules command prefix
+cmd="ipfw -q add"
+vpn="tun0"
+
+# allow all local traffic on the loopback interface
+$cmd 00001 allow all from any to any via lo0
+
+# allow any connection to/from VPN interface
+$cmd 00010 allow all from any to any via $vpn
+
+# allow connection to/from LAN by transmission
+$cmd 00101 allow all from me to 192.168.0.0/16 uid transmission
+$cmd 00102 allow all from 192.168.0.0/16 to me uid transmission
+
+# deny any rTorrent connection outside LAN that does not use VPN
+$cmd 00103 deny all from any to any uid transmission

--- a/jails/transvpn/includes/ipfw.rules
+++ b/jails/transvpn/includes/ipfw.rules
@@ -4,7 +4,7 @@ ipfw -q -f flush
 
 # Set rules command prefix
 cmd="ipfw -q add"
-vpn="tun0"
+vpn="#TUNDEV#"
 
 # allow all local traffic on the loopback interface
 $cmd 00001 allow all from any to any via lo0
@@ -16,5 +16,5 @@ $cmd 00010 allow all from any to any via $vpn
 $cmd 00101 allow all from me to 192.168.0.0/16 uid transmission
 $cmd 00102 allow all from 192.168.0.0/16 to me uid transmission
 
-# deny any rTorrent connection outside LAN that does not use VPN
+# deny any connection outside LAN that does not use VPN
 $cmd 00103 deny all from any to any uid transmission

--- a/jails/transvpn/install.sh
+++ b/jails/transvpn/install.sh
@@ -1,17 +1,18 @@
 #!/usr/local/bin/bash
-# This file contains the install script for transmission
+# This file contains the install script for transmission + vpn
+set -eao pipefail
 
 # Check if dataset Downloads dataset exist, create if they do not.
-createmount transvpn ${global_dataset_downloads}trov /mnt/downloads
+createmount transvpn "${global_dataset_downloads}trov" /mnt/downloads
 
 # Check if dataset Complete Downloads dataset exist, create if they do not.
-createmount transvpn ${global_dataset_downloads}trov/complete /mnt/downloads/complete
+createmount transvpn "${global_dataset_downloads}trov/complete" /mnt/downloads/complete
 
 # Check if dataset InComplete Downloads dataset exist, create if they do not.
-createmount transvpn ${global_dataset_downloads}trov/incomplete /mnt/downloads/incomplete
+createmount transvpn "${global_dataset_downloads}trov/incomplete" /mnt/downloads/incomplete
 
 # Copy ipfw rules to jail, replacing #TUNDEV# with tundev (default "tun0")
-sed -e "s/#TUNDEV#/${transvpn_tundev:-tun0}/g" < ${SCRIPT_DIR}/jails/transvpn/includes/ipfw.rules > /mnt/${global_dataset_iocage}/jails/transvpn/root/etc/ipfw.rules
+sed -e "s/#TUNDEV#/${transvpn_tundev:-tun0}/g" < "${SCRIPT_DIR}/jails/transvpn/includes/ipfw.rules" > "/mnt/${global_dataset_iocage}/jails/transvpn/root/etc/ipfw.rules"
 
 iocage exec transvpn chown -R transmission:transmission /config
 iocage exec transvpn sysrc "transmission_enable=YES"
@@ -20,7 +21,7 @@ iocage exec transvpn sysrc "transmission_download_dir=/mnt/downloads/complete"
 
 iocage exec transvpn sysrc "openvpn_enable=YES"
 iocage exec transvpn mkdir /usr/local/etc/openvpn
-cp ${SCRIPT_DIR}/${transvpn_ovpnconf} /mnt/${global_dataset_iocage}/jails/transvpn/root/usr/local/etc/openvpn/
+cp "${SCRIPT_DIR}/${transvpn_ovpnconf}" "/mnt/${global_dataset_iocage}/jails/transvpn/root/usr/local/etc/openvpn/"
 iocage exec transvpn sysrc "firewall_enable=YES"
 iocage exec transvpn sysrc "firewall_script=/etc/ipfw.rules"
 iocage exec transvpn sed -i '' -e 's/\([[:space:]]*"rpc-whitelist-enabled":[[:space:]]*\)true,/\1false,/' /etc/ipfw.rules

--- a/jails/transvpn/install.sh
+++ b/jails/transvpn/install.sh
@@ -1,0 +1,33 @@
+#!/usr/local/bin/bash
+# This file contains the install script for transmission
+
+# Check if dataset Downloads dataset exist, create if they do not.
+createmount transvpn ${global_dataset_downloads}trov /mnt/downloads
+
+# Check if dataset Complete Downloads dataset exist, create if they do not.
+createmount transvpn ${global_dataset_downloads}trov/complete /mnt/downloads/complete
+
+# Check if dataset InComplete Downloads dataset exist, create if they do not.
+createmount transvpn ${global_dataset_downloads}trov/incomplete /mnt/downloads/incomplete
+
+cp ${SCRIPT_DIR}/jails/transvpn/includes/ipfw.rules /mnt/${global_dataset_iocage}/jails/transvpn/root/etc/ipfw.rules
+
+iocage exec transvpn chown -R transmission:transmission /config
+iocage exec transvpn sysrc "transmission_enable=YES"
+iocage exec transvpn sysrc "transmission_conf_dir=/config"
+iocage exec transvpn sysrc "transmission_download_dir=/mnt/downloads/complete"
+
+iocage exec transvpn sysrc "openvpn_enable=YES"
+iocage exec transvpn mkdir /usr/local/etc/openvpn
+cp ${SCRIPT_DIR}/${transvpn_ovpnconf} /mnt/${global_dataset_iocage}/jails/transvpn/root/usr/local/etc/openvpn/
+iocage exec transvpn sysrc "firewall_enable=YES"
+iocage exec transvpn sysrc "firewall_script=/etc/ipfw.rules"
+
+iocage exec transvpn service ipfw restart
+iocage exec transvpn service openvpn restart
+
+echo "Disabling RPC whitelist, you may want to reenable it with the specific IP's you will access transmission with by editing /config/settings.json"
+iocage exec transvpn service transmission stop
+iocage exec transvpn sed -i '' -e 's/\([[:space:]]*"rpc-whitelist-enabled":[[:space:]]*\)true,/\1false,/' /config/settings.json
+
+iocage exec transvpn service transmission start

--- a/jails/transvpn/install.sh
+++ b/jails/transvpn/install.sh
@@ -10,7 +10,8 @@ createmount transvpn ${global_dataset_downloads}trov/complete /mnt/downloads/com
 # Check if dataset InComplete Downloads dataset exist, create if they do not.
 createmount transvpn ${global_dataset_downloads}trov/incomplete /mnt/downloads/incomplete
 
-cp ${SCRIPT_DIR}/jails/transvpn/includes/ipfw.rules /mnt/${global_dataset_iocage}/jails/transvpn/root/etc/ipfw.rules
+# Copy ipfw rules to jail, replacing #TUNDEV# with tundev (default "tun0")
+sed -e "s/#TUNDEV#/${transvpn_tundev:-tun0}/g" < ${SCRIPT_DIR}/jails/transvpn/includes/ipfw.rules > /mnt/${global_dataset_iocage}/jails/transvpn/root/etc/ipfw.rules
 
 iocage exec transvpn chown -R transmission:transmission /config
 iocage exec transvpn sysrc "transmission_enable=YES"
@@ -22,6 +23,7 @@ iocage exec transvpn mkdir /usr/local/etc/openvpn
 cp ${SCRIPT_DIR}/${transvpn_ovpnconf} /mnt/${global_dataset_iocage}/jails/transvpn/root/usr/local/etc/openvpn/
 iocage exec transvpn sysrc "firewall_enable=YES"
 iocage exec transvpn sysrc "firewall_script=/etc/ipfw.rules"
+iocage exec transvpn sed -i '' -e 's/\([[:space:]]*"rpc-whitelist-enabled":[[:space:]]*\)true,/\1false,/' /etc/ipfw.rules
 
 iocage exec transvpn service ipfw restart
 iocage exec transvpn service openvpn restart

--- a/openvpn.conf.example
+++ b/openvpn.conf.example
@@ -1,1 +1,3 @@
 # Provide your own configuration here
+# The device should match the tundev setting
+dev tun1001

--- a/openvpn.conf.example
+++ b/openvpn.conf.example
@@ -1,0 +1,1 @@
+# Provide your own configuration here


### PR DESCRIPTION
Globally, this adds a service_extraconf variable for passing arbitrary values to iocage.

Using that capability, this PR adds transvpn (transmission+openvpn) and qbitvpn(qbittorrent+openvpn). The strange tun workaround is needed on my system for some reason, possibly related to other users of tun. (Openvpn cannot automatically allocate one, and tun## below around 100 are unavailable to the jail.)

Comments welcome, especially interested in improvements to the ipfw and vpn config import portions.